### PR TITLE
Make account customizations optional

### DIFF
--- a/terraform/modules/aft-account-request/ddb.tf
+++ b/terraform/modules/aft-account-request/ddb.tf
@@ -1,25 +1,12 @@
 resource "aws_dynamodb_table_item" "account-request" {
-  table_name = var.account-request-table
-  hash_key   = var.account-request-table-hash
+  table_name = var.account_request_table
+  hash_key   = var.account_request_table_hash
 
-  item = jsonencode({
-    id = { S = lookup(var.control_tower_parameters, "AccountEmail") }
-    control_tower_parameters = { M = {
-      AccountEmail              = { S = lookup(var.control_tower_parameters, "AccountEmail") }
-      AccountName               = { S = lookup(var.control_tower_parameters, "AccountName") }
-      ManagedOrganizationalUnit = { S = lookup(var.control_tower_parameters, "ManagedOrganizationalUnit") }
-      SSOUserEmail              = { S = lookup(var.control_tower_parameters, "SSOUserEmail") }
-      SSOUserFirstName          = { S = lookup(var.control_tower_parameters, "SSOUserFirstName") }
-      SSOUserLastName           = { S = lookup(var.control_tower_parameters, "SSOUserLastName") }
-      }
-    }
-    change_management_parameters = { M = {
-      change_reason       = { S = lookup(var.change_management_parameters, "change_reason") }
-      change_requested_by = { S = lookup(var.change_management_parameters, "change_requested_by") }
-      }
-    }
-    account_tags                = { S = jsonencode(var.account_tags) }
-    account_customizations_name = { S = var.account_customizations_name }
-    custom_fields               = { S = jsonencode(var.custom_fields) }
+  item = templatefile("${path.module}/templates/ddb-item.json.tftpl", {
+    control_tower_parameters = var.control_tower_parameters
+    change_management_parameters = var.change_management_parameters
+    account_tags = var.account_tags
+    custom_fields = var.custom_fields
+    account_customizations_name = var.account_customizations_name
   })
 }

--- a/terraform/modules/aft-account-request/templates/ddb-item.json.tftpl
+++ b/terraform/modules/aft-account-request/templates/ddb-item.json.tftpl
@@ -1,0 +1,32 @@
+{
+  "id": {
+    "S": ${jsonencode(lookup(control_tower_parameters, "AccountEmail"))}
+  },
+  "control_tower_parameters": {
+    "M": {
+      "AccountEmail"              : { "S": ${jsonencode(lookup(control_tower_parameters, "AccountEmail"))} },
+      "AccountName"               : { "S": ${jsonencode(lookup(control_tower_parameters, "AccountName"))} },
+      "ManagedOrganizationalUnit" : { "S": ${jsonencode(lookup(control_tower_parameters, "ManagedOrganizationalUnit"))} },
+      "SSOUserEmail"              : { "S": ${jsonencode(lookup(control_tower_parameters, "SSOUserEmail"))} },
+      "SSOUserFirstName"          : { "S": ${jsonencode(lookup(control_tower_parameters, "SSOUserFirstName"))} },
+      "SSOUserLastName"           : { "S": ${jsonencode(lookup(control_tower_parameters, "SSOUserLastName"))} }
+    }
+  },
+  "change_management_parameters": {
+    "M" : {
+      "change_reason"       : { "S": ${jsonencode(lookup(change_management_parameters, "change_reason"))} },
+      "change_requested_by" : { "S": ${jsonencode(lookup(change_management_parameters, "change_requested_by"))} }
+    }
+  },
+  %{~ if length(keys(account_tags)) > 0 ~}
+  "account_tags": ${ jsonencode({ S = jsonencode(account_tags) }) },
+  %{~ endif ~}
+  %{~ if length(keys(custom_fields)) > 0 ~}
+  "custom_fields": ${ jsonencode({ S = jsonencode(custom_fields) }) },
+  %{~ endif ~}
+  %{~ if account_customizations_name == "" ~}
+  "account_customizations_name": { "NULL": true }
+  %{~ else ~}
+  "account_customizations_name": { "S": ${jsonencode(account_customizations_name)} }
+  %{~ endif ~}
+}

--- a/terraform/modules/aft-account-request/variables.tf
+++ b/terraform/modules/aft-account-request/variables.tf
@@ -1,10 +1,10 @@
-variable "account-request-table" {
+variable "account_request_table" {
   type        = string
   description = "name of account-request-table"
   default     = "aft-request"
 }
 
-variable "account-request-table-hash" {
+variable "account_request_table_hash" {
   type        = string
   description = "name of account-request-table hash key"
   default     = "id"


### PR DESCRIPTION
This project was failing to create the dynamodb item if the account customization name was blank because dynamodb does not accept empty fields. The terraform jsonencode() function was failing to JSON encode the object `{ "NULL" = true }` into a JSON string, so I changed the module to use a template and manually create the JSON for better control over the final result.

Not a pro with terraform so please check the template and make sure that everything is escaped properly. I've used jsonencode on every value passed into the template so it shouldn't be possible to inject anything.

Also I changed a couple of variables to use snake case in order to follow [Terraform naming conventions](https://www.terraform-best-practices.com/naming).